### PR TITLE
Fix two very minor Javadoc defects

### DIFF
--- a/json/src/main/java/org/quiltmc/parsers/json/JsonFormat.java
+++ b/json/src/main/java/org/quiltmc/parsers/json/JsonFormat.java
@@ -21,8 +21,7 @@ package org.quiltmc.parsers.json;
  */
 public enum JsonFormat {
     /**
-     * The standard, (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>) JSON.
-     *  JSON5</a> or strict JSON
+     * The standard, <a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a> JSON.
      */
     JSON,
     /**

--- a/json/src/main/java/org/quiltmc/parsers/json/JsonReader.java
+++ b/json/src/main/java/org/quiltmc/parsers/json/JsonReader.java
@@ -86,7 +86,7 @@ import java.util.Objects;
  *   {
  *   /*
  *    * Look mom, block comments!
- *   *\/
+ *    *\/
  *     "id": 912345678902,
  *     "text": "@json_newb just use JsonReader!",
  *     "geo": [-Infinity, NaN], // wow, broken floating point types!


### PR DESCRIPTION
* `JsonFormat.JSON`: Removed weird half-sentence and unmatched </a> tag at the end of the Javadoc, also removed parentheses around the RFC link.
* `JsonReader`: Fixed indentation in example JSON5 snippet (sadly, I couldn't figure out a way to have a proper `*/` sequence in a block comment).