### PR TITLE
Make JsonReader.locationString public

### DIFF
--- a/json/src/main/java/org/quiltmc/parsers/json/JsonReader.java
+++ b/json/src/main/java/org/quiltmc/parsers/json/JsonReader.java
@@ -1575,7 +1575,7 @@ public final class JsonReader implements Closeable {
 		return false;
 	}
 
-	String locationString() {
+	public String locationString() {
 		int line = lineNumber + 1;
 		int column = pos - lineStart + 1;
 		return " at line " + line + " column " + column + " path " + path();


### PR DESCRIPTION
This is necessary for changing loader to use this library rather than json5 ([JsonLoaderValue#L47](https://github.com/QuiltMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/impl/metadata/qmj/JsonLoaderValue.java#L47) uses this, for example).